### PR TITLE
FE-5391: remove placement level x-fade check

### DIFF
--- a/src/player.js
+++ b/src/player.js
@@ -349,7 +349,7 @@ Player.prototype._onStations = function(stations) {
 Player.prototype._onStationChanged = function(stationId, station) {
   this._station = station;
 
-  if (this.serverAssignedCrossfade && station.options && ('crossfade_seconds' in station.options)) {
+  if (station.options && ('crossfade_seconds' in station.options)) {
     // apply station level crossfade, if available
     this.secondsOfCrossfade = station.options.crossfade_seconds;
     


### PR DESCRIPTION
This placement-level crossfade check is causing crossfades not to function with the recent publishing changes. This PR simply removes that check.

FE-5333
FE-5391